### PR TITLE
log grid (truncation error)

### DIFF
--- a/src/addit/ditlog.py
+++ b/src/addit/ditlog.py
@@ -41,8 +41,6 @@ def folded_voigt_kernel_log(k,log_nbeta,log_ngammaL,dLarray):
     
     return val
 
-
-
 @jit
 def rundit_fold_log(S,nu_lines,beta,gammaL,nu_grid,R,nbeta_grid,ngammaL_grid,dLarray):
     """run DIT folded voigt for an arbitrary ESLOG
@@ -61,7 +59,6 @@ def rundit_fold_log(S,nu_lines,beta,gammaL,nu_grid,R,nbeta_grid,ngammaL_grid,dLa
     Returns:
        Cross section
 
-    
     """
 
 
@@ -91,9 +88,9 @@ def rundit_fold_log(S,nu_lines,beta,gammaL,nu_grid,R,nbeta_grid,ngammaL_grid,dLa
 
     return xs
 
-#@jit
-def rundit_fold_logdv(S,nu_lines,beta,gammaL,nu_grid,nbeta_grid,ngammaL_grid,dLarray,dv_lines,dv_grid):
-    """run DIT folded voigt for an arbitrary ESLOG 
+@jit
+def rundit_fold_logred(S,nu_lines,beta,gammaL,nu_grid,nbeta_grid,ngammaL_grid,dLarray,dv_lines,dv_grid):
+    """run DIT folded voigt for ESLOG for reduced wavenumebr inputs (against the truncation error)
 
     Args:
        S: line strength (Nlines)
@@ -104,8 +101,8 @@ def rundit_fold_logdv(S,nu_lines,beta,gammaL,nu_grid,nbeta_grid,ngammaL_grid,dLa
        nbeta_grid: normalized beta grid 
        ngammaL_grid: normalized gammaL grid
        dLarray: dLarray
-       dv_lines: 
-       dv_grid:
+       dv_lines: delta wavenumber for lines i.e. nu_lines/R
+       dv_grid: delta wavenumber for nu_grid i.e. nu_grid/R
 
     Returns:
        Cross section
@@ -133,6 +130,6 @@ def rundit_fold_logdv(S,nu_lines,beta,gammaL,nu_grid,nbeta_grid,ngammaL_grid,dLa
     fftval = jnp.fft.rfft(valbuf,axis=0)
     vk=folded_voigt_kernel_log(k, log_nbeta_grid,log_ngammaL_grid,dLarray)
     fftvalsum = jnp.sum(fftval*vk,axis=(1,2))
-    xs=jnp.fft.irfft(fftvalsum)[:Ng_nu]/dvgrid
+    xs=jnp.fft.irfft(fftvalsum)[:Ng_nu]/dv_grid
     
     return xs

--- a/tests/ditfold_test.py
+++ b/tests/ditfold_test.py
@@ -5,10 +5,9 @@ from addit.ncf import inc3D
 np.random.seed(20)
 
 N=2000
-#Ng_nu=20000
-Ng_nu=30000
-Ng_beta=20
-Ng_gammaL=20
+Ng_nu=100000
+Ng_beta=30
+Ng_gammaL=30
 
 nus=np.linspace(2050.0,2150.0,Ng_nu) #nu grid
 beta=np.random.rand(N)*0.99+0.01
@@ -20,12 +19,11 @@ S=np.logspace(0.0,3.0,N)
 nu_lines=np.random.rand(N)*(nus[-1]-nus[0]-50.0)+nus[0]+25.0
 
 F0=rundit(S,nu_lines,beta,gammaL,nus,beta_grid,gammaL_grid)
-
+nn=np.median(nus)
 dnu=nus[1]-nus[0]
 dLarray=make_dLarray(2,dnu)
-F0=rundit(S,nu_lines,beta,gammaL,nus,beta_grid,gammaL_grid)
-F0f1=runditfold(S,nu_lines,beta,gammaL,nus,beta_grid,gammaL_grid,1,dLarray)
-F0f2=runditfold(S,nu_lines,beta,gammaL,nus,beta_grid,gammaL_grid,2,dLarray)
+F0=rundit(S,nu_lines-nn,beta,gammaL,nus-nn,beta_grid,gammaL_grid)
+F0f1=runditfold(S,nu_lines-nn,beta,gammaL,nus-nn,beta_grid,gammaL_grid,1,dLarray)
 
 import matplotlib.pyplot as plt
 from exojax.spec import xsection
@@ -36,12 +34,10 @@ ax=fig.add_subplot(211)
 plt.plot(nus,xsv,label="direct")
 plt.plot(nus,F0,label="DIT (0)",ls="dashed")
 plt.plot(nus,F0f1,label="DIT (1)",ls="dashed")
-plt.plot(nus,F0f2,label="DIT (2)",ls="dotted")
-plt.plot(nus,F0f2-xsv,label="DIT-direct")
+plt.plot(nus,F0f1-xsv,label="DIT-direct")
 plt.legend()
 ax=fig.add_subplot(212)
 plt.plot(nus,F0-xsv,label="DIT-direct (0)",alpha=0.3)
 plt.plot(nus,F0f1-xsv,label="DIT-direct (1)",alpha=0.3)
-plt.plot(nus,F0f2-xsv,label="DIT-direct (2)",alpha=0.3)
 plt.legend()
 plt.show()

--- a/tests/ditlog_test.py
+++ b/tests/ditlog_test.py
@@ -1,12 +1,12 @@
 from addit.dit import rundit, runditfold, runditf1, make_dLarray
-from addit.ditlog import rundit_fold_log
+from addit.ditlog import rundit_fold_log,  rundit_fold_logdv
 import jax.numpy as jnp
 import numpy as np
 from addit.ncf import inc3D
 np.random.seed(20)
 
 N=2000
-Ng_nu=20000
+Ng_nu=100000
 Ng_beta=30
 Ng_gammaL=30
 
@@ -22,12 +22,25 @@ gammaL=np.random.rand(N)*1.0
 S=np.logspace(0.0,3.0,N)
 nu_lines=np.random.rand(N)*(nus[-1]-nus[0]-50.0)+nus[0]+25.0
 
+
 nbeta_grid=np.logspace(np.log10(np.min(beta/nu_lines*R)),np.log10(np.max(beta/nu_lines*R)),Ng_beta) 
 ngammaL_grid=np.logspace(np.log10(np.min(gammaL/nu_lines*R)),np.log10(np.max(gammaL/nu_lines*R)),Ng_gammaL)
+
+
+#direct dv needs to be careful for the truncation error
+nn=np.median(nus)
+dvx = jnp.interp(nu_lines-nn, nus[1:-1]-nn, 0.5*(nus[2:] - nus[:-2]))
+nbeta_grid_=np.logspace(np.log10(np.min(beta/dvx)),np.log10(np.max(beta/dvx)),Ng_beta) 
+ngammaL_grid_=np.logspace(np.log10(np.min(gammaL/dvx)),np.log10(np.max(gammaL/dvx)),Ng_gammaL)
+
 
 dLarray=make_dLarray(2,1.0)
 Nfold=1
 F0f2=rundit_fold_log(S,nu_lines,beta,gammaL,nus,R,nbeta_grid,ngammaL_grid,dLarray)
+
+#direct dv
+F0f2_=rundit_fold_logdv(S,nu_lines-nn,beta,gammaL,nus-nn,R,nbeta_grid_,ngammaL_grid_,dLarray)
+
 
 import matplotlib.pyplot as plt
 from exojax.spec import xsection
@@ -39,8 +52,12 @@ ax=fig.add_subplot(211)
 plt.plot(nus,xsv,label="direct")
 plt.plot(nus,F0f2,label="DIT (Nfold="+str(Nfold)+")",ls="dashed")
 plt.plot(nus,F0f2-xsv,label="DIT-direct")
+plt.plot(nus,F0f2_-xsv,label="DIT-direct (direct dv)")
+
 plt.legend()
 ax=fig.add_subplot(212)
 plt.plot(nus,F0f2-xsv,label="DIT-log",alpha=0.3)
+plt.plot(nus,F0f2_-xsv,label="DIT-log (direct dv)",alpha=0.3)
+
 plt.legend()
 plt.show()

--- a/tests/ditlog_test.py
+++ b/tests/ditlog_test.py
@@ -1,5 +1,5 @@
 from addit.dit import rundit, runditfold, runditf1, make_dLarray
-from addit.ditlog import rundit_fold_log,  rundit_fold_logdv
+from addit.ditlog import rundit_fold_log,  rundit_fold_logred
 import jax.numpy as jnp
 import numpy as np
 from addit.ncf import inc3D
@@ -33,9 +33,7 @@ S=np.logspace(0.0,3.0,N)
 S[0:20]=1.e5
 beta[0:20]=0.01
 gammaL[0:20]=0.01
-
 nu_lines=np.random.rand(N)*(nus[-1]-nus[0]-50.0)+nus[0]+25.0
-
 
 nbeta_grid=np.logspace(np.log10(np.min(beta/nu_lines*R)),np.log10(np.max(beta/nu_lines*R)),Ng_beta) 
 ngammaL_grid=np.logspace(np.log10(np.min(gammaL/nu_lines*R)),np.log10(np.max(gammaL/nu_lines*R)),Ng_gammaL)
@@ -57,12 +55,11 @@ F0f2=rundit_fold_log(S,nu_lines,beta,gammaL,nus,R,nbeta_grid,ngammaL_grid,dLarra
 #care for truncation
 dvx=nu_lines/R
 dv=nus/R
-F0f2_=rundit_fold_logdv(S,nu_lines-nn,beta,gammaL,nus-nn,R,nbeta_grid_,ngammaL_grid_,dLarray,dvx,dv)
-print(F0f2_)
+F0f2_=rundit_fold_logred(S,nu_lines-nn,beta,gammaL,nus-nn,nbeta_grid_,ngammaL_grid_,dLarray,dvx,dv)
 
+#direct voigt for comparison
 import matplotlib.pyplot as plt
 from exojax.spec import xsection
-#direct
 xsv=xsection(nus,nu_lines,beta,gammaL,S)
 
 fig=plt.figure()
@@ -70,13 +67,14 @@ ax=fig.add_subplot(211)
 plt.plot(nus,xsv,label="direct")
 plt.plot(nus,F0f2,label="DIT (Nfold="+str(Nfold)+")",ls="dashed")
 plt.plot(nus,F0f2-xsv,label="DIT-direct")
-plt.plot(nus,F0f2_-xsv,label="DIT-direct (imp)")
+plt.plot(nus,F0f2_-xsv,label="DIT-direct (reduced $\nu$)")
 #plt.xlim(2113.2,2113.5)
 
 plt.legend()
 ax=fig.add_subplot(212)
-plt.plot(nus,F0f2-xsv,label="DIT-log",alpha=0.3)
-plt.plot(nus,F0f2_-xsv,label="DIT-log (imp)",alpha=0.3)
+plt.plot(nus,(F0f2-xsv),label="DIT/log",alpha=0.3)
+plt.plot(nus,(F0f2_-xsv),label="DIT/log (reduced $\nu$)",alpha=0.3)
+plt.ylabel("difference")
 #plt.xlim(2113.2,2113.5)
 plt.legend()
 plt.show()

--- a/tests/ditlog_test.py
+++ b/tests/ditlog_test.py
@@ -16,10 +16,24 @@ nu1=2150.0
 nus=np.logspace(np.log10(nu0),np.log10(nu1),Ng_nu) #nu grid
 R=(Ng_nu-1)/np.log(nu1/nu0) #resolution
 
+
+dvc=nus/R
+dvv = jnp.interp(nus, nus[1:-1], 0.5*(nus[2:] - nus[:-2]))
+
+#import matplotlib.pyplot as plt
+#plt.plot(nus,dvc-dvv,".")
+#plt.show()
+#import sys
+#sys.exit()
+
 beta=np.random.rand(N)*0.99+0.01
 gammaL=np.random.rand(N)*1.0
 #L grid
 S=np.logspace(0.0,3.0,N)
+S[0:20]=1.e5
+beta[0:20]=0.01
+gammaL[0:20]=0.01
+
 nu_lines=np.random.rand(N)*(nus[-1]-nus[0]-50.0)+nus[0]+25.0
 
 
@@ -29,7 +43,9 @@ ngammaL_grid=np.logspace(np.log10(np.min(gammaL/nu_lines*R)),np.log10(np.max(gam
 
 #direct dv needs to be careful for the truncation error
 nn=np.median(nus)
-dvx = jnp.interp(nu_lines-nn, nus[1:-1]-nn, 0.5*(nus[2:] - nus[:-2]))
+
+#dvx = jnp.interp(nu_lines-nn, nus[1:-1]-nn, 0.5*(nus[2:] - nus[:-2]))
+dvx=nu_lines/R
 nbeta_grid_=np.logspace(np.log10(np.min(beta/dvx)),np.log10(np.max(beta/dvx)),Ng_beta) 
 ngammaL_grid_=np.logspace(np.log10(np.min(gammaL/dvx)),np.log10(np.max(gammaL/dvx)),Ng_gammaL)
 
@@ -38,9 +54,11 @@ dLarray=make_dLarray(2,1.0)
 Nfold=1
 F0f2=rundit_fold_log(S,nu_lines,beta,gammaL,nus,R,nbeta_grid,ngammaL_grid,dLarray)
 
-#direct dv
-F0f2_=rundit_fold_logdv(S,nu_lines-nn,beta,gammaL,nus-nn,R,nbeta_grid_,ngammaL_grid_,dLarray)
-
+#care for truncation
+dvx=nu_lines/R
+dv=nus/R
+F0f2_=rundit_fold_logdv(S,nu_lines-nn,beta,gammaL,nus-nn,R,nbeta_grid_,ngammaL_grid_,dLarray,dvx,dv)
+print(F0f2_)
 
 import matplotlib.pyplot as plt
 from exojax.spec import xsection
@@ -52,12 +70,13 @@ ax=fig.add_subplot(211)
 plt.plot(nus,xsv,label="direct")
 plt.plot(nus,F0f2,label="DIT (Nfold="+str(Nfold)+")",ls="dashed")
 plt.plot(nus,F0f2-xsv,label="DIT-direct")
-plt.plot(nus,F0f2_-xsv,label="DIT-direct (direct dv)")
+plt.plot(nus,F0f2_-xsv,label="DIT-direct (imp)")
+#plt.xlim(2113.2,2113.5)
 
 plt.legend()
 ax=fig.add_subplot(212)
 plt.plot(nus,F0f2-xsv,label="DIT-log",alpha=0.3)
-plt.plot(nus,F0f2_-xsv,label="DIT-log (direct dv)",alpha=0.3)
-
+plt.plot(nus,F0f2_-xsv,label="DIT-log (imp)",alpha=0.3)
+#plt.xlim(2113.2,2113.5)
 plt.legend()
 plt.show()


### PR DESCRIPTION
rundit_fold_logred is the log grid version of DIT, with the reduced wavenumber grids/line center as inputs to avoid the truncation errors due to float32.  